### PR TITLE
Allow the admin to configure multiple VLANs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -97,7 +97,7 @@ Enumerates the customization specifications registered in the target datacenter.
    --cspec CUST_SPEC - The name of any customization specification to apply
    --cplugin CUST_PLUGIN_PATH - Path to plugin that implements KnifeVspherePlugin.customize_clone_spec and/or KnifeVspherePlugin.reconfig_vm
    --cplugin-data CUST_PLUGIN_DATA - String of data to pass to the plugin.  Use any format you wish.
-   --cvlan CUST_VLAN - VLAN name for network adapter to join
+   --cvlan CUST_VLANS - Comma-delimited list of VLAN names for the network adapters to join
    --cips CUST_IPS - Comma-delimited list of CIDR IPs for customization, or *dhcp* to configure that interface to use DHCP
    --cgw CUST_GW - CIDR IP of gateway for customization
    --chostname CUST_HOSTNAME - Unqualified hostname for customization


### PR DESCRIPTION
The current plugin lets you configure multiple NICs with unique IPs
through a comma separated list, e.g. --cips a,b,c but does not offer the
same for VLANs (--cvlan). Only the first NIC can have its VLAN changed.

This commit adds multiple VLAN support to --cvlan

`--cvlan="18 dmz,202 foo-stg" --cips 1.1.1.1/24,2.2.2.2/24`

It will throw an error if you supply more VLANs than there are NICs, but
keeps the old behaviour where you have more NICS than options specified
in --cvlan. That is, they are not changed from the template.