### PR TITLE
Support cloning VM with a DHCP address

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -98,7 +98,7 @@ Enumerates the customization specifications registered in the target datacenter.
    --cplugin CUST_PLUGIN_PATH - Path to plugin that implements KnifeVspherePlugin.customize_clone_spec and/or KnifeVspherePlugin.reconfig_vm
    --cplugin-data CUST_PLUGIN_DATA - String of data to pass to the plugin.  Use any format you wish.
    --cvlan CUST_VLAN - VLAN name for network adapter to join
-   --cips CUST_IPS - Comma-delimited list of CIDR IPs for customization
+   --cips CUST_IPS - Comma-delimited list of CIDR IPs for customization, or *dhcp* to configure that interface to use DHCP
    --cgw CUST_GW - CIDR IP of gateway for customization
    --chostname CUST_HOSTNAME - Unqualified hostname for customization
    --cdomain CUST_DOMAIN - Domain name for customization

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -495,15 +495,15 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
   end
 
   # Generates a CustomizationAdapterMapping (currently only single IPv4 address) object
-  # @param ip [String] Any static IP address to use, otherwise DHCP
+  # @param ip [String] Any static IP address to use, or "dhcp" for DHCP
   # @param gw [String] If static, the gateway for the interface, otherwise network address + 1 will be used
   # @return [RbVmomi::VIM::CustomizationIPSettings]
   def generate_adapter_map (ip=nil, gw=nil, dns1=nil, dns2=nil, domain=nil)
 
     settings = RbVmomi::VIM.CustomizationIPSettings
 
-    if ip.nil?
-      settings.ip = RbVmomi::VIM::CustomizationDhcpIpGenerator
+    if ip.nil? || ip.downcase == "dhcp"
+      settings.ip = RbVmomi::VIM::CustomizationDhcpIpGenerator.new
     else
       cidr_ip = NetAddr::CIDR.create(ip)
       settings.ip = RbVmomi::VIM::CustomizationFixedIp(:ipAddress => cidr_ip.ip)


### PR DESCRIPTION
Allow the operator to pass `dhcp` instead of an IP address in the
`--cips` option, which will configure that particular interface with
DHCP.