### PR TITLE
Add obfuscated password storage

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -48,6 +48,10 @@ For initial development, the plugin targets all communication at a vCenter insta
     knife[:vsphere_pass] = "your password"
     knife[:vsphere_dc] = "your-datacenter"
 
+The vSphere password can also be stored in a base64 encoded version (to visually obfuscate it) by prepending 'base64:' to your encoded password. For example:
+
+    knife[:vsphere_pass] = "base64:VGhhbmtzRXpyYSE=\n"
+
 If you get the following error, you may need to disable SSL certificate checking:
 ERROR: OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
     knife[:vsphere_insecure] = true

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -6,6 +6,7 @@
 
 require 'chef/knife'
 require 'rbvmomi'
+require 'base64'
 
 # Base class for vsphere knife commands
 class Chef
@@ -101,10 +102,12 @@ class Chef
             :proxyPort => get_config(:proxy_port)
         }
 
-        # Grab the password from the command line
-        # if tt is not in the config file
-        if not conn_opts[:password]
+        if !conn_opts[:password]
+          # Password is not in the config file - grab it
+          # from the command line
           conn_opts[:password] = get_password
+        elsif conn_opts[:password].start_with?('base64:')
+          conn_opts[:password] = Base64.decode64(conn_opts[:password][7..-1])
         end
 
         #    opt :debug, "Log SOAP messages", :short => 'd', :default => (ENV['RBVMOMI_DEBUG'] || false)


### PR DESCRIPTION
There are times when it would be nice to have the vSphere password stored for scripted use, but leaving it in plaintext is a little more easily shoulder-surfable than I'd like. I've added an option to store the vSphere password base64-encoded, so it's less obvious on casual inspection that my password matches my luggage combination.

(not sure if this is too hacky, but since it's useful to me I thought I'd toss it out here)
