### PR TITLE
Bugfix for base64 encoded passwords and bootstrap secret-file option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -124,6 +124,7 @@ Enumerates the customization specifications registered in the target datacenter.
    --distro DISTRO - Bootstrap a distro using a template
    --template-file TEMPLATE - Full path to location of template to use
    --run-list RUN_LIST - Comma separated list of roles/recipes to apply
+   --secret-file SECRET_FILE - A file containing the secret key to use to encrypt data bag item values
    --no-host-key-verify - Disable host key verification
    --json-attributes - A JSON string to be added to the first run of chef-client
    --disable-customization - Disable default customization
@@ -139,13 +140,13 @@ Customization Plugin Example:
       def data=(cplugin_data)
         # Parse your cplugin_data from the format of your choosing.
       end
-    
+
       # optional
       def customize_clone_spec(src_config, clone_spec)
         # Customize the clone spec as you see fit.
         return customized_clone_spec
       end
-    
+
       # optional
       def reconfig_vm(target_vm)
         # Do anything you want in here with the cloned VM.
@@ -272,7 +273,7 @@ Gets the datastorecluster with the most free space
 
 == knife vsphere vm execute VMNAME COMMAND [ARGUMENTS] --exec-user USER --exec-passwd PASSWD [ --exec-dir DIRECTORY ]
 
-Executes a program on the guest. Requires vCenter 5.0 or higher. 
+Executes a program on the guest. Requires vCenter 5.0 or higher.
 
 Command path must be absolute. For Linux guest operating systems,
 /bin/bash is used to start the program. For Solaris guest operating

--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "knife-vsphere"
-  s.version = "1.0.0"
+  s.version = "1.0.1"
   s.summary = "vSphere Support for Knife"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.6.2"
   s.homepage = 'http://github.com/ezrapagel/knife-vsphere'
   s.license = 'Apache'
-  s.add_dependency('netaddr', ["~> 1.5.0"])
-  s.add_dependency('chef', [">= 0.10.0"])
-  s.add_dependency('rbvmomi', ["~> 1.5.1"])
+  s.add_dependency('netaddr', ['~> 1.5'])
+  s.add_dependency('chef', ['>= 0.10.0'])
+  s.add_dependency('rbvmomi', ['~> 1.8'])
 end

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -107,7 +107,7 @@ class Chef
           # from the command line
           conn_opts[:password] = get_password
         elsif conn_opts[:password].start_with?('base64:')
-          conn_opts[:password] = Base64.decode64(conn_opts[:password][7..-1])
+          conn_opts[:password] = Base64.decode64(conn_opts[:password][7..-1]).chomp
         end
 
         #    opt :debug, "Log SOAP messages", :short => 'd', :default => (ENV['RBVMOMI_DEBUG'] || false)
@@ -207,7 +207,7 @@ class Chef
             if baseEntity.is_a? RbVmomi::VIM::Folder
               baseEntity = baseEntity.childEntity.find { |f| f.name == entityArrItem } or
                   abort "no such pool #{poolName} while looking for #{entityArrItem}"
-            elsif baseEntity.is_a? RbVmomi::VIM::ClusterComputeResource or baseEntity.is_a? RbVmomi::VIM::ComputeResource 
+            elsif baseEntity.is_a? RbVmomi::VIM::ClusterComputeResource or baseEntity.is_a? RbVmomi::VIM::ComputeResource
               baseEntity = baseEntity.resourcePool.resourcePool.find { |f| f.name == entityArrItem } or
                   abort "no such pool #{poolName} while looking for #{entityArrItem}"
             elsif baseEntity.is_a? RbVmomi::VIM::ResourcePool
@@ -276,7 +276,7 @@ class Chef
       end
 
       def find_datastorecluster(dsName, folder = nil)
-        if ! folder 
+        if ! folder
           dc = get_datacenter
           folder = dc.datastoreFolder
         end

--- a/lib/chef/knife/vsphere_pool_list.rb
+++ b/lib/chef/knife/vsphere_pool_list.rb
@@ -15,8 +15,10 @@ class Chef::Knife::VspherePoolList < Chef::Knife::BaseVsphereCommand
   def traverse_folders(folder)
     return if folder.is_a? RbVmomi::VIM::VirtualApp
 
-    puts "#{ui.color("Pool", :cyan)}: "+(folder.path[3..-1].map { |x| x[1] }.* '/') if
-      folder.is_a? RbVmomi::VIM::ResourcePool
+    if folder.is_a? RbVmomi::VIM::ResourcePool
+      pools = folder.path[3..-1].reject { |p| p.last == "Resources" }
+      puts "#{ui.color("Pool", :cyan)}: " + pools.map(&:last).join('/')
+    end
 
     folders = find_all_in_folder(folder, RbVmomi::VIM::ManagedObject) || []
     folders.each do |child|

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -190,8 +190,8 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   option :secret_file,
          :long => "--secret-file SECRET_FILE",
-         :description => "A file containing the secret key to use to encrypt data bag item values"
-  $default[:secret_file] = ''
+         :description => "A file containing the secret key to use to encrypt data bag item values",
+         :proc => lambda { |secret_file| Chef::Config[:knife][:secret_file] = secret_file }
 
   option :hint,
          :long => "--hint HINT_NAME[=HINT_FILE]",


### PR DESCRIPTION
### I found two bugs while using the knife-vshpere plug-in. ###

### 1. The ruby function for base64 decoding appends a "\n" to your password. ###

```
- conn_opts[:password] = Base64.decode64(conn_opts[:password][7..-1])
+ conn_opts[:password] = Base64.decode64(conn_opts[:password][7..-1])[0..-2]
```

### 2. If we want to use a secet_file during chef bootstrap we have to set the secret_file configuration option for chef. ###

```
- $default[:secret_file] = ''
+ :proc => lambda { |secret_file| Chef::Config[:knife][:secret_file] = secret_file }
```

I also updated the gemspec file to a new chef version and counted the gem version to 1.0.1.