### PR TITLE
Add vault options for bootstrapping

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -121,6 +121,9 @@ Enumerates the customization specifications registered in the target datacenter.
    --prerelease - Install the pre-release chef gems
    --bootstrap-version VERSION - The version of Chef to install
    --bootstrap-proxy PROXY_URL - The proxy server for the node being bootstrapped
+   --bootstrap-vault-file VAULT_FILE - A JSON file with a list of vault(s) and item(s) to be updated
+   --bootstrap-vault-json VAULT_JSON - A JSON string with the vault(s) and item(s) to be updated
+   --bootstrap-vault-item VAULT_ITEM - A single vault and item to update as "vault:item"
    --distro DISTRO - Bootstrap a distro using a template
    --template-file TEMPLATE - Full path to location of template to use
    --run-list RUN_LIST - Comma separated list of roles/recipes to apply
@@ -227,6 +230,18 @@ Customization Plugin Example:
         "host_name": "foo_host",
         "timeZone": "100"
     }
+
+
+The <tt>--bootstrap-vault-*</tt> options can be used to send <tt>chef-vault</tt> items to be updated during the hand-off to <tt>knife bootstrap</tt>.
+
+Example using <tt>--bootstrap-vault-json</tt>:
+
+    knife vsphere vm clone NewNode UbuntuTemplate --cspec StaticSpec \
+        --cips 192.168.0.99/24,192.168.1.99/24 \
+        --chostname NODENAME --cdomain NODEDOMAIN \
+        --start true --bootstrap true \
+        --bootstrap-vault-json '{"passwords":"default","appvault":"credentials"}'
+
 
 == knife vsphere vm toolsconfig PROPERTY VALUE [--empty]
     --empty           - allows clearing string properties

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -172,6 +172,25 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          description: 'The proxy server for the node being bootstrapped',
          proc: proc { |p| Chef::Config[:knife][:bootstrap_proxy] = p }
 
+  option :bootstrap_vault_file,
+         long: '--bootstrap-vault-file VAULT_FILE',
+         description: 'A JSON file with a list of vault(s) and item(s) to be updated'
+
+  option :bootstrap_vault_json,
+         long: '--bootstrap-vault-json VAULT_JSON',
+         description: 'A JSON string with the vault(s) and item(s) to be updated'
+
+  option :bootstrap_vault_item,
+         long: '--bootstrap-vault-item VAULT_ITEM',
+         description: 'A single vault and item to update as "vault:item"',
+         proc: Proc.new { |i|
+           (vault, item) = i.split(/:/)
+           Chef::Config[:knife][:bootstrap_vault_item] ||= {}
+           Chef::Config[:knife][:bootstrap_vault_item][vault] ||= []
+           Chef::Config[:knife][:bootstrap_vault_item][vault].push(item)
+           Chef::Config[:knife][:bootstrap_vault_item]
+         }
+
   option :distro,
          short: '-d DISTRO',
          long: '--distro DISTRO',
@@ -550,6 +569,9 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     bootstrap.config[:environment] = get_config(:environment)
     bootstrap.config[:first_boot_attributes] = get_config(:first_boot_attributes)
     bootstrap.config[:log_level] = get_config(:log_level)
+    bootstrap.config[:bootstrap_vault_file] = get_config(:bootstrap_vault_file)
+    bootstrap.config[:bootstrap_vault_json] = get_config(:bootstrap_vault_json)
+    bootstrap.config[:bootstrap_vault_item] = get_config(:bootstrap_vault_item)
     # may be needed for vpc_mode
     bootstrap.config[:no_host_key_verify] = get_config(:no_host_key_verify)
     bootstrap


### PR DESCRIPTION
Hey guys,

These are options that we at PBP have been using for a month or so now to assist us with provisioning hosts with vSphere. All this patch really does is add the `--bootstrap-vault-*` options to the plugin so that it will support vault updates upon bootstrap hand-off.

Would love to see this in future releases to make it easier to re-deploy our tools.

Thanks!

--Chris
