### PR TITLE
Improve the way we find a host

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 knife-vsphere changelog
 ----------------------
 
+1.1.2   Learath  - Improve the way we find a host to clone to
+
 1.1.1   DennisBP - Possibility to generate random VMNAMEs
         swalberg - Fix some arguments that used vshere
                  - Add a Gemfile to the repository

--- a/README.rdoc
+++ b/README.rdoc
@@ -411,3 +411,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Software changes provided by Nicholas Brisebois at Dell SecureWorks. For more
+information on Dell SecureWorks security services please browse to
+http://www.secureworks.com
+
+Copyright 2015 Dell SecureWorks

--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'knife-vsphere'
-  s.version = '1.1.1'
+  s.version = '1.1.2'
   s.summary = 'vSphere Support for Knife'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -139,6 +139,19 @@ class Chef
         false
       end
 
+      def traverse_folders_for_computeresources(folder)
+        retval = []
+        children = folder.children.find_all
+        children.each do |child|
+          if child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource
+            retval << child
+          elsif child.class == RbVmomi::VIM::Folder
+            retval.concat(traverse_folders_for_computeresources(child))
+          end
+        end
+        retval
+      end
+
       def traverse_folders_for_vms(folder, vmname)
         retval = []
         children = folder.children.find_all

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -359,29 +359,28 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       dc = datacenter
       hosts = traverse_folders_for_computeresources(dc.hostFolder)
       fatal_exit('No ComputeResource found - Use --resource-pool to specify a resource pool or a cluster') if hosts.empty?
-      hosts.reject!{ |host| host.nil? }
-      hosts.reject!{ |host| host.host.all?{ |h| h.runtime.inMaintenanceMode } }
-      if hosts.empty?
-        fatal_exit "All hosts in maintenance mode!"
-      end
+      hosts.reject!(&:nil?)
+      hosts.reject! { |host| host.host.all? { |h| h.runtime.inMaintenanceMode } }
+      fatal_exit 'All hosts in maintenance mode!' if hosts.empty?
+
       if get_config(:datastore)
-        hosts.reject!{ |host| !host.datastore.include?(find_datastore(get_config(:datastore))) }
+        hosts.reject! { |host| !host.datastore.include?(find_datastore(get_config(:datastore))) }
       end
-      if hosts.empty?
-        fatal_exit "No hosts have the requested Datastore available! #{get_config(:datastore)}"
-      end
+
+      fatal_exit "No hosts have the requested Datastore available! #{get_config(:datastore)}" if hosts.empty?
+
       if get_config(:datastorecluster)
-        hosts.reject!{ |host| !host.datastore.include?(find_datastorecluster(get_config(:datastorecluster))) }
+        hosts.reject! { |host| !host.datastore.include?(find_datastorecluster(get_config(:datastorecluster))) }
       end
-      if hosts.empty?
-        fatal_exit "No hosts have the requested DatastoreCluster available! #{get_config(:datastorecluster)}"
-      end
+
+      fatal_exit "No hosts have the requested DatastoreCluster available! #{get_config(:datastorecluster)}" if hosts.empty?
+
       if get_config(:customization_vlan)
-        hosts.reject!{ |host| !host.network.include?(find_network(get_config(:customization_vlan))) }
+        hosts.reject! { |host| !host.network.include?(find_network(get_config(:customization_vlan))) }
       end
-      if hosts.empty?
-        fatal_exit "No hosts have the requested Network available! #{get_config(:customization_vlan)}"
-      end
+
+      fatal_exit "No hosts have the requested Network available! #{get_config(:customization_vlan)}" if hosts.empty?
+
       rp = hosts.first.resourcePool
       rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(pool: rp)
     end


### PR DESCRIPTION
Submitted by Learath (Nicholas Brisebois) from Dell SecureWorks. See
https://github.com/ezrapagel/knife-vsphere/issues/162

This patch improves the way hosts are located when creating the original
clone spec. Before this patch we'd simply grab the first host we saw
even if it was in maintenance mode or was missing resources needed by
the VM. Now, do some more stringent checking such as removing hosts in
maintenance mode, and check to make sure the user isn't asking for a
datastore that has no available hosts.