### PR TITLE
Update the docs to clarify two boolean options.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -112,8 +112,8 @@ Enumerates the customization specifications registered in the target datacenter.
    --ctz CUST_TIMEZONE - Timezone invalid 'Area/Location' format
    --ccpu CUST_CPU_COUNT - Number of CPUs
    --cram CUST_MEMORY_GB - Gigabytes of RAM
-   --start STARTVM - Indicates whether to start the VM after a successful clone
-   --bootstrap FALSE - Indicates whether to bootstrap the VM
+   --start - Start the VM after cloning.
+   --bootstrap - Bootstrap the VM after cloning. Implies --start
    --fqdn SERVER_FQDN - Fully qualified hostname for bootstrapping
    --ssh-user USERNAME - SSH username
    --ssh-password PASSWORD - SSH password


### PR DESCRIPTION
Fixes #183. The docs seem to indicate that if you don't want to
bootstrap the node after cloning then you can pass `--bootstrap false`
which is not the case. Update documentation for bootstrap and start
which falls into the same category.