### PR TITLE
Followup to Issue #191

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -332,7 +332,7 @@ Optional arguments
 
 == knife vsphere vm markastemplate VMNAME --folder FOLDER
 
-Will travserse the folder tree looking for the VM by name.  By default the folder inspected with be the root folder.  --folder should be specified if traversing should be in some other folder than the root.  Once found the VM will be converted into a template.  This means the VM will become a template and no longer be available as a Virtual Machine.  The name given to the template will be the name of VM from which it was created.
+Will travserse the folder tree looking for the VM by name.  By default the folder inspected with be the root folder.  --folder should be specified if traversing should begin in some other folder than the root.  Once found the VM will be converted into a template.  This means the VM will become a template and no longer be available as a VM.  The name given to the template will be the name of VM from which it was created.
 
 == knife vsphere hosts list --pool POOL
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -332,7 +332,7 @@ Optional arguments
 
 == knife vsphere vm markastemplate VMNAME --folder FOLDER
 
-Marks a VM as template.
+Will travserse the folder tree looking for the VM by name.  By default the folder inspected with be the root folder.  --folder should be specified if traversing should be in some other folder than the root.  Once found the VM will be converted into a template.  This means the VM will become a template and no longer be available as a Virtual Machine.  The name given to the template will be the name of VM from which it was created.
 
 == knife vsphere hosts list --pool POOL
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -598,7 +598,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       if customization_plugin && customization_plugin.respond_to?(:customize_clone_spec)
         clone_spec = customization_plugin.customize_clone_spec(src_config, clone_spec)
       end
+    else
+      clone_spec.customization = cust_spec    
     end
+    
     clone_spec
   end
 

--- a/lib/chef/knife/vsphere_vm_markastemplate.rb
+++ b/lib/chef/knife/vsphere_vm_markastemplate.rb
@@ -20,7 +20,9 @@ class Chef::Knife::VsphereVmMarkastemplate < Chef::Knife::BaseVsphereCommand
 
   option :folder,
          long: '--folder FOLDER',
-         description: 'The folder which contains the VM'
+         description: 'The folder which contains the VM',
+         default: ''
+
 
   def run
     $stdout.sync = true


### PR DESCRIPTION
depending on your perspective of what "customization" means in this context... or more specifically what disabling of customization means, this change may or may not seem appropriate.  Currently there is way means to instruct the tool to not try to intervene with the cspec that's passed.  it will do so it if thinks it needs to.  THis seems like problematic behavior and there should be some way to tell it never to do this.  short of adding another parameter, --disable_customization seems appropriate for this.  if --disable_customization is specified, it honor what's fetched by the cspec look up as-is

Originating Issue:
https://github.com/ezrapagel/knife-vsphere/issues/191