### PR TITLE
making --disable-customization work with --cspec

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -102,6 +102,7 @@ Enumerates the customization specifications registered in the target datacenter.
    --resource-pool POOL - The resource pool into which to put the cloned VM
    --template TEMPLATE - The source VM / Template to clone from
    --cspec CUST_SPEC - The name of any customization specification to apply
+   --disable-customization FALSE - by default conventions will be applied to the customization specification (see below).  Disable these convention with this switch
    --cplugin CUST_PLUGIN_PATH - Path to plugin that implements KnifeVspherePlugin.customize_clone_spec and/or KnifeVspherePlugin.reconfig_vm
    --cplugin-data CUST_PLUGIN_DATA - String of data to pass to the plugin.  Use any format you wish.
    --cvlan CUST_VLANS - Comma-delimited list of VLAN names for the network adapters to join
@@ -136,10 +137,11 @@ Enumerates the customization specifications registered in the target datacenter.
    --disable-customization - Disable default customization
    --sysprep_timeout TIMEOUT - Wait TIMEOUT seconds for sysprep event before continuing with bootstrap
 
+Clones an existing VM template into a new VM instance, optionally applying an existing customization specification.  If customization arguments such as --chost and --cdomain are specified, or if the customization sepcification fetched from VSphere is considered, a default customization specification will be attempted.  For windows, a sysprep based unattended customization in workgroup mode will be attempted (host name being the VM name unless otherwise specified).  For linux, a fixed named customization using the vmname as the host name unless otherwise specified.  These customization specification defaults can be disabled using the --disable-customization switch and the --cspec specified as-is.
 
-Clones an existing VM template into a new VM instance, optionally applying an existing customization specification.
+NOTE!  if you are specifying a --cspec and the cloning process appears to not be properly applying the spec as defined on VSphere, consider using the --disable-customization as the conventions described above could be erroneously interfering with the spec as defined on VSphere.
 
-Customization Plugin Example:
+Customization specifications can also be specified in code using the --cplugin and/or --cplugin-data arguments.  Below are examples of the potential implementations that woudl be saved to an rb file and passed in the --cplugin argument.
 
 # cplugin_example.rb
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -536,7 +536,9 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       end
     end
 
-    unless get_config(:disable_customization)
+    if get_config(:disable_customization)
+      clone_spec.customization = cust_spec    
+    else
       use_ident = !config[:customization_hostname].nil? || !get_config(:customization_domain).nil? || cust_spec.identity.nil?
 
       if use_ident


### PR DESCRIPTION
changing the meaning of --disable-customization slightly (or finishing it's implementation - depending on your perspective).  if --cspec is specified as well as --disable-customization then the --cspec will be used as-is with no intervention from the plugin code

updating doc accordingly