### PR TITLE
make markastemplate work by default

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -332,8 +332,8 @@ Optional arguments
 
 == knife vsphere vm markastemplate VMNAME --folder FOLDER
 
-Marks a VM as template.
-
+Will traverse the folder tree looking for the VM by name.  By default the folder inspected with be the root folder.  <tt>--folder</tt> should be specified if traversing should be in some other folder than the root.  Once found the VM will be converted into a template.  This means the VM will become a template and no longer be available as a Virtual Machine.  The name given to the template will be the name of VM from which it was created.
+ 
 == knife vsphere hosts list --pool POOL
 
 Lists all hosts in given Pool

--- a/lib/chef/knife/vsphere_vm_markastemplate.rb
+++ b/lib/chef/knife/vsphere_vm_markastemplate.rb
@@ -20,7 +20,8 @@ class Chef::Knife::VsphereVmMarkastemplate < Chef::Knife::BaseVsphereCommand
 
   option :folder,
          long: '--folder FOLDER',
-         description: 'The folder which contains the VM'
+         description: 'The folder which contains the VM',
+         default: ''
 
   def run
     $stdout.sync = true


### PR DESCRIPTION
better explaining what happens when using markastemplate making folder operation to avoid a nil ref exception when the optional --folder argument is not supplied